### PR TITLE
#4 update gps recorder service for deployment specific output directories

### DIFF
--- a/service.nix
+++ b/service.nix
@@ -16,10 +16,10 @@ in {
         description = "The package to use for the gps recorder.";
       };
 
-      output-path = lib.mkOption {
+      output-folder = lib.mkOption {
         type = lib.types.str;
-        default = "/output/gps";
-        description = "The folder to save recordings to.";
+        default = "gps";
+        description = "The folder to save recordings to within the deployment directory.";
       };
 
       interval-secs = lib.mkOption {
@@ -66,9 +66,11 @@ in {
       script = ''
         #!/usr/bin/env bash
         set -x
-        ${pkgs.coreutils}/bin/mkdir -p ${config.services.gps-recorder.output-path}
+        # DEPLOYMENT_DIRECTORY is set by the deployment-start service
+        OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.gps-recorder.output-folder}
+        ${pkgs.coreutils}/bin/mkdir -p $OUTPUT_PATH
         RUST_LOG=info ${gpsRecorder}/bin/gps-recorder \
-        --output-path ${config.services.gps-recorder.output-path} \
+        --output-path $OUTPUT_PATH \
         --interval ${toString config.services.gps-recorder.interval-secs} \
         --hostname ${config.services.gps-recorder.hostname} \
         --port ${toString config.services.gps-recorder.port} \
@@ -79,7 +81,7 @@ in {
         Restart = "always";
       };
       unitConfig = {
-        After = ["multi-user.target"];
+        After = ["multi-user.target" "deployment-start.service"];
       };
       startLimitIntervalSec = 0;
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ impl GpsRecorder {
             error!("Error connecting to GPSD");
             std::process::exit(1);
         };
-        let filename = format!("{}_GPS_data.json", Utc::now().format("%Y-%m-%dT%H-%M-%S"));
+        let filename = format!("{}_GPS_data.json", Utc::now().format("%Y-%m-%dT%H_%M_%S%z"));
         let file_path = path.join(filename);
         info!("Writing GPS data to {}", file_path.display());
         File::create(&file_path).unwrap();


### PR DESCRIPTION
This PR updates gps-recorder service output path creation.

Previously, the absolute path to the data-specific directory was passed through the `output-path` option of the service (`/output/gps`). Now, the service reads `DEPLOYMENT_DIRECTORY` environment variable and appends to that the value of `output-folder` option. `output-folder` now designates the folder to be created within the deployment specific output directory where gps data should be written to. Default value for `output-folder` is `gps`.

Also, the output file name format is updated to `%Y-%m-%dT%H_%M_%S%z`, updating delimiters and adding time zone information.

Closes #4 